### PR TITLE
Update type definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@ On the top-level, a document is a JSON-object with a `type` property and some cu
 
 ```json
 {
-  "type": "article",
-  "title": "Sinus und Kosinus",
-  "content":
-    "nested subdocument ... ",
+  "type": "https://serlo.org/editor",
+  "content": {
+    "plugin": "article",
+    "state": ...
+  },
   "__meta_version": 1
 }
 ```


### PR DESCRIPTION
@Entkenntnis This is something to discuss. I feel like on root level we need a good marker to check for the editor type. My question: shall start the JSON tree with the first plugin: 

```json
{
  "__meta_type": "https://serlo.org/editor",
  "__meta_version": 1,
  "plugin": "article",
  "state": {}
}
```

or

```json
{
  "type": "https://serlo.org/editor",
  "__meta_version": 1,
  "mainContentOfEntity": {
    "plugin": "article",
    "state": {}
  }
}
```

What do you think? 